### PR TITLE
chore(ci): ♻️ Bump MSRV in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = [
 version = "0.7.0"
 edition = "2021"
 # Update the MSRV variable in .github/workflows/ci.yml when changing this.
-rust-version = "1.80"
+rust-version = "1.81"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/criterion-rs/criterion.rs"
 readme = "README.md"


### PR DESCRIPTION
half@2.7.1 requires rustc 1.81
check cargo-audit action