### PR TITLE
Add support for reporting throughput and elements simultaneously.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+ - `Throughput::ElementsAndBytes` added to allow the text summary to report throughput in both units simultaneously.
+
 ## [0.7.0] - 2025-07-25
 - Bump version of criterion-plot to align dependencies.
 

--- a/benches/benchmarks/custom_measurement.rs
+++ b/benches/benchmarks/custom_measurement.rs
@@ -1,10 +1,14 @@
-use criterion::{
-    criterion_group,
-    measurement::{Measurement, ValueFormatter},
-    Criterion, Throughput,
+use {
+    criterion::{
+        criterion_group,
+        measurement::{Measurement, ValueFormatter},
+        Criterion, Throughput,
+    },
+    std::{
+        hint::black_box,
+        time::{Duration, Instant},
+    },
 };
-use std::hint::black_box;
-use std::time::{Duration, Instant};
 
 struct HalfSecFormatter;
 impl ValueFormatter for HalfSecFormatter {
@@ -27,6 +31,11 @@ impl ValueFormatter for HalfSecFormatter {
             Throughput::Elements(elems) => format!(
                 "{} elem/s/2",
                 (elems as f64) / (value * 2f64 * 10f64.powi(-9))
+            ),
+            Throughput::ElementsAndBytes { elements, bytes } => format!(
+                "{} elem/s/2, {} b/s/2",
+                (elements as f64) / (value * 2f64 * 10f64.powi(-9)),
+                (bytes as f64) / (value * 2f64 * 10f64.powi(-9))
             ),
         }
     }
@@ -66,6 +75,9 @@ impl ValueFormatter for HalfSecFormatter {
                 }
 
                 "elem/s/2"
+            }
+            Throughput::ElementsAndBytes { elements, bytes: _ } => {
+                self.scale_throughputs(_typical, &Throughput::Elements(elements), values)
             }
         }
     }

--- a/benches/benchmarks/with_inputs.rs
+++ b/benches/benchmarks/with_inputs.rs
@@ -22,6 +22,18 @@ fn from_elem(c: &mut Criterion) {
         });
     }
     group.finish();
+
+    let mut group = c.benchmark_group("from_elem_dual_throughput");
+    for size in [KB, 2 * KB].iter() {
+        group.throughput(Throughput::ElementsAndBytes {
+            elements: *size as u64,
+            bytes: 2 * *size as u64,
+        });
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+            b.iter(|| iter::repeat(0u16).take(size).collect::<Vec<_>>());
+        });
+    }
+    group.finish();
 }
 
 criterion_group!(benches, from_elem);

--- a/book/src/user_guide/advanced_configuration.md
+++ b/book/src/user_guide/advanced_configuration.md
@@ -119,6 +119,9 @@ alloc                   time:   [5.9846 ms 6.0192 ms 6.0623 ms]
                         thrpt:  [164.95 MiB/s 166.14 MiB/s 167.10 MiB/s]  
 ```
 
+You can also request that the throughput measure both elements/s and bytes/s if, for example, you're doing some kind of data processing and
+want to understand both the number of records/s and the total bytes/s achieved. This is achieved by setting `throughput` to `Throughput::ElementsAndBytes`.
+
 ## Chart Axis Scaling
 
 By default, Criterion.rs generates plots using a linear-scale axis. When using parameterized benchmarks, it is common for the input sizes to scale exponentially in order to cover a wide range of possible inputs. In this situation, it may be easier to read the resulting plots with a logarithmic axis.

--- a/src/csv_report.rs
+++ b/src/csv_report.rs
@@ -1,11 +1,14 @@
-use crate::error::Result;
-use crate::measurement::ValueFormatter;
-use crate::report::{BenchmarkId, MeasurementData, Report, ReportContext};
-use crate::Throughput;
-use csv::Writer;
-use serde::Serialize;
-use std::io::Write;
-use std::path::Path;
+use {
+    crate::{
+        error::Result,
+        measurement::ValueFormatter,
+        report::{BenchmarkId, MeasurementData, Report, ReportContext},
+        Throughput,
+    },
+    csv::Writer,
+    serde::Serialize,
+    std::{io::Write, path::Path},
+};
 
 #[derive(Serialize)]
 struct CsvRow<'a> {
@@ -38,6 +41,10 @@ impl<W: Write> CsvReportWriter<W> {
             Some(Throughput::Bytes(bytes)) => (Some(format!("{}", bytes)), Some("bytes")),
             Some(Throughput::BytesDecimal(bytes)) => (Some(format!("{}", bytes)), Some("bytes")),
             Some(Throughput::Elements(elems)) => (Some(format!("{}", elems)), Some("elements")),
+            Some(Throughput::ElementsAndBytes { elements, bytes }) => (
+                Some(format!("{}/{}", elements, bytes)),
+                Some("elements/bytes"),
+            ),
             Some(Throughput::Bits(bits)) => (Some(format!("{}", bits)), Some("bits")),
             None => (None, None),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1259,6 +1259,11 @@ where
 // TODO: Remove serialize/deserialize from the public API.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Throughput {
+    /// Measure throughput in terms of bits/second. The value should be the number of bits
+    /// processed by one iteration of the benchmarked code. Typically, this would be the number of
+    /// bits transferred by a networking function.
+    Bits(u64),
+
     /// Measure throughput in terms of bytes/second. The value should be the number of bytes
     /// processed by one iteration of the benchmarked code. Typically, this would be the length of
     /// an input string or `&[u8]`.
@@ -1275,10 +1280,22 @@ pub enum Throughput {
     /// parse.
     Elements(u64),
 
-    /// Measure throughput in terms of bits/second. The value should be the number of bits
-    /// processed by one iteration of the benchmarked code. Typically, this would be the number of
-    /// bits transferred by a networking function.
-    Bits(u64),
+    /// Measure throughput in terms of both elements/second and bytes/second. Typically,
+    /// this would be used if you have a collection of rows where `elements` would be the length of
+    /// the collection and `bytes` would be the total size of the collection if you're processing
+    /// the entire collection in one iteration. This will make sure the report simultaneously
+    /// includes on the rows/s and MB/s that data processing is able to achieve.
+    /// The elements are considered the "primary" throughput being reported on (i.e. what will appear
+    /// in the BenchmarkId).
+    ElementsAndBytes {
+        /// The value should be the number of elements processed by one iteration of the benchmarked code.
+        /// Typically, this would be the size of a collection, but could also be the number of lines of
+        /// input text or the number of values to parse.
+        elements: u64,
+        /// The value should be the number of bytes processed by one iteration of the benchmarked code.
+        /// Typically, this would be the length of an input string or `&[u8]`.
+        bytes: u64,
+    },
 }
 
 /// Axis scaling type. Specified via [`PlotConfiguration::summary_scale`].

--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -195,12 +195,16 @@ impl ValueFormatter for DurationFormatter {
         values: &mut [f64],
     ) -> &'static str {
         match *throughput {
+            Throughput::Bits(bits) => self.bits_per_second(bits as f64, typical, values),
             Throughput::Bytes(bytes) => self.bytes_per_second(bytes as f64, typical, values),
             Throughput::BytesDecimal(bytes) => {
                 self.bytes_per_second_decimal(bytes as f64, typical, values)
             }
             Throughput::Elements(elems) => self.elements_per_second(elems as f64, typical, values),
-            Throughput::Bits(bits) => self.bits_per_second(bits as f64, typical, values),
+            // The caller should be formatting the bytes and elements separately.
+            Throughput::ElementsAndBytes { elements, bytes: _ } => {
+                self.elements_per_second(elements as f64, typical, values)
+            }
         }
     }
 

--- a/src/plot/gnuplot_backend/summary.rs
+++ b/src/plot/gnuplot_backend/summary.rs
@@ -1,16 +1,24 @@
-use super::{debug_script, gnuplot_escape};
-use super::{DARK_BLUE, DEFAULT_FONT, KDE_POINTS, LINEWIDTH, POINT_SIZE, SIZE};
-use crate::kde;
-use crate::measurement::ValueFormatter;
-use crate::plot::LinePlotConfig;
-use crate::report::{BenchmarkId, ValueType};
-use crate::stats::univariate::Sample;
-use crate::AxisScale;
-use criterion_plot::prelude::*;
-use itertools::Itertools;
-use std::cmp::Ordering;
-use std::path::{Path, PathBuf};
-use std::process::Child;
+use {
+    super::{
+        debug_script, gnuplot_escape, DARK_BLUE, DEFAULT_FONT, KDE_POINTS, LINEWIDTH, POINT_SIZE,
+        SIZE,
+    },
+    crate::{
+        kde,
+        measurement::ValueFormatter,
+        plot::LinePlotConfig,
+        report::{BenchmarkId, ValueType},
+        stats::univariate::Sample,
+        AxisScale,
+    },
+    criterion_plot::prelude::*,
+    itertools::Itertools,
+    std::{
+        cmp::Ordering,
+        path::{Path, PathBuf},
+        process::Child,
+    },
+};
 
 const NUM_COLORS: usize = 8;
 static COMPARISON_COLORS: [Color; NUM_COLORS] = [
@@ -103,7 +111,7 @@ pub(crate) fn line_comparison(
                 (x, y[0])
             })
             .collect();
-        tuples.sort_by(|&(ax, _), &(bx, _)| (ax.partial_cmp(&bx).unwrap_or(Ordering::Less)));
+        tuples.sort_by(|&(ax, _), &(bx, _)| ax.partial_cmp(&bx).unwrap_or(Ordering::Less));
         let (xs, ys): (Vec<_>, Vec<_>) = tuples.into_iter().unzip();
 
         let function_name = key.as_ref().map(|string| gnuplot_escape(string));

--- a/src/plot/mod.rs
+++ b/src/plot/mod.rs
@@ -114,10 +114,20 @@ impl LinePlotConfig {
                 let to = max_id.throughput.as_ref().unwrap();
 
                 let (from_bytes, to_bytes) = match (from, to) {
+                    (Throughput::Bits(from), Throughput::Bits(to)) => (from, to),
                     (Throughput::Bytes(from), Throughput::Bytes(to)) => (from, to),
                     (Throughput::BytesDecimal(from), Throughput::BytesDecimal(to)) => (from, to),
                     (Throughput::Elements(from), Throughput::Elements(to)) => (from, to),
-                    (Throughput::Bits(from), Throughput::Bits(to)) => (from, to),
+                    (
+                        Throughput::ElementsAndBytes {
+                            elements: _,
+                            bytes: from,
+                        },
+                        Throughput::ElementsAndBytes {
+                            elements: _,
+                            bytes: to,
+                        },
+                    ) => (from, to),
                     _ => unreachable!("throughput types expected to be equal"),
                 };
 

--- a/src/plot/plotters_backend/summary.rs
+++ b/src/plot/plotters_backend/summary.rs
@@ -1,12 +1,13 @@
-use super::*;
-use crate::AxisScale;
-use itertools::Itertools;
-use plotters::coord::{
-    ranged1d::{AsRangedCoord, ValueFormatter as PlottersValueFormatter},
-    Shift,
+use {
+    super::*,
+    crate::AxisScale,
+    itertools::Itertools,
+    plotters::coord::{
+        ranged1d::{AsRangedCoord, ValueFormatter as PlottersValueFormatter},
+        Shift,
+    },
+    std::{cmp::Ordering, path::Path},
 };
-use std::cmp::Ordering;
-use std::path::Path;
 
 const NUM_COLORS: usize = 8;
 static COMPARISON_COLORS: [RGBColor; NUM_COLORS] = [
@@ -159,7 +160,7 @@ fn line_comparison_series_data<'a>(
                 (x, y[0])
             })
             .collect();
-        tuples.sort_by(|&(ax, _), &(bx, _)| (ax.partial_cmp(&bx).unwrap_or(Ordering::Less)));
+        tuples.sort_by(|&(ax, _), &(bx, _)| ax.partial_cmp(&bx).unwrap_or(Ordering::Less));
         let function_name = key.as_ref();
         let (xs, ys): (Vec<_>, Vec<_>) = tuples.into_iter().unzip();
         series_data.push((function_name, xs, ys));


### PR DESCRIPTION
Only hooked up for the CLI reporter for now, but it's pretty useful when doing data processing to understand both throughput variants when you're doing batch processing.

Original PR https://github.com/bheisler/criterion.rs/pull/722
Closes #10