### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     |
     <a href="https://criterion-rs.github.io/book/index.html">User Guide</a>
     |
-    <a href="https://docs.rs/crate/criterion/">Released API Docs</a>
+    <a href="https://docs.rs/criterion">Released API Docs</a>
     |
     <a href="https://github.com/criterion-rs/criterion.rs/blob/master/CHANGELOG.md">Changelog</a>
 </div>
@@ -47,7 +47,7 @@ To start with Criterion.<span></span>rs, add the following to your `Cargo.toml` 
 
 ```toml
 [dev-dependencies]
-criterion = { version = "0.7", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 
 [[bench]]
 name = "my_benchmark"
@@ -111,7 +111,7 @@ For more details, see the [CONTRIBUTING.md file](https://github.com/criterion-rs
 Criterion.<span></span>rs supports the last three stable minor releases of Rust. At time of
 writing, this means Rust 1.88 or later. Older versions may work, but are not guaranteed.
 
-Currently, the oldest version of Rust believed to work is 1.80. Future versions of Criterion.<span></span>rs may
+Currently, the oldest version of Rust believed to work is 1.86. Future versions of Criterion.<span></span>rs may
 break support for such old versions, and this will not be considered a breaking change. If you
 require Criterion.<span></span>rs to work on old versions of Rust, you will need to stick to a
 specific patch version of Criterion.<span></span>rs.


### PR DESCRIPTION
- Update doc link to link to documentation instead of crate page
- Update listed version number to 0.8
- Update minimum supported Rust version to 1.86 as was changed in #22