### PR TITLE
Exclude development scripts from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.86"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/criterion-rs/criterion.rs"
 readme = "README.md"
+include = ["Cargo.toml", "CHANGELOG.md", "README.md", "LICENSE-MIT", "LICENSE-APACHE", "src/**/*.rs"]
 
 [package]
 name = "criterion"


### PR DESCRIPTION
During a dependency review we noticed that the criterion crate includes various development scripts. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from being included in the published packages to make sure that everything that's included is an conscious choice.