### PR TITLE
fix: don't build alloca on unsupported targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ version.workspace = true
 exclude = ["book/*"]
 
 [dependencies]
-alloca = "0.4"
 anes = "0.1.4"
 criterion-plot = { path = "plot", version = "0.8.1" }
 itertools = "0.13"
@@ -60,6 +59,9 @@ smol = { version = "2.0", default-features = false, optional = true }
 tokio = { version = "1.0", default-features = false, features = [
     "rt",
 ], optional = true }
+
+[target.'cfg(any(windows, unix))'.dependencies]
+alloca = "0.4"
 
 [dependencies.plotters]
 version = "^0.3.2"


### PR DESCRIPTION
It seems like alloca adds a C compiler + libc requirement which can complicate builds.

Example failed build on WASI: https://github.com/eternal-flame-AD/pow-buster/actions/runs/20703460407/job/59429401253 . 

I tried a couple packages to rectify the situation with no avail and the problem doesn't occur on my local machine. Regardless since we are only using it on unix and windows I think it is best to only build it on those targets.

Good build with the patch: https://github.com/eternal-flame-AD/pow-buster/actions/runs/20704600981/job/59432555818
