### PR TITLE
Fix panic with uniform iteration durations in benchmarks

### DIFF
--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -465,6 +465,18 @@ fn test_criterion_doesnt_panic_if_measured_time_is_zero() {
     });
 }
 
+#[test]
+fn test_criterion_doesnt_panic_with_uniform_durations() {
+    // Reproduces issue #873: iter_custom returning uniform durations
+    // (iters milliseconds) causes panic during chart generation due to
+    // zero variance leading to zero bandwidth in KDE calculation.
+    let dir = temp_dir();
+    let mut c = short_benchmark(&dir);
+    c.bench_function("uniform_durations", |bencher| {
+        bencher.iter_custom(|iters| Duration::from_millis(iters));
+    });
+}
+
 mod macros {
     use super::{criterion_group, criterion_main, Criterion};
 


### PR DESCRIPTION
When all benchmark iterations report identical durations, criterion.rs would panic during chart generation with "assertion failed: !(range.0.is_nan() || range.1.is_nan())". This occurred because the Silverman bandwidth calculation produced zero when standard deviation was zero, leading to division by zero in the KDE sweep code and ultimately NaN values in chart coordinates.

This fix adds a fallback bandwidth when standard deviation is zero, using 1% of the data range (or 1% of the absolute value if all values are identical, or a minimal epsilon for all-zero data). This is semantically correct because KDE assumes data has spread; when variance is zero, we provide minimal artificial bandwidth to create a narrow distribution centered on the actual value.

The fix is scale-invariant and handles all edge cases while preserving existing behavior for benchmarks with variance.

Fixes [#873](https://github.com/bheisler/criterion.rs/issues/873)