### PR TITLE
fix: include bench names in quick bencher report

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -744,18 +744,17 @@ pub struct BencherReport;
 impl Report for BencherReport {
     fn measurement_start(
         &self,
-        id: &BenchmarkId,
+        _id: &BenchmarkId,
         _context: &ReportContext,
         _sample_count: u64,
         _estimate_ns: f64,
         _iter_count: u64,
     ) {
-        print!("test {} ... ", id);
     }
 
     fn measurement_complete(
         &self,
-        _id: &BenchmarkId,
+        id: &BenchmarkId,
         _: &ReportContext,
         meas: &MeasurementData<'_>,
         formatter: &dyn ValueFormatter,
@@ -767,7 +766,7 @@ impl Report for BencherReport {
         let unit = formatter.scale_for_machines(&mut values);
 
         println!(
-            "bench: {:>11} {}/iter (+/- {})",
+            "test {id} ... bench: {:>11} {}/iter (+/- {})",
             format::integer(values[0]),
             unit,
             format::integer(values[1])


### PR DESCRIPTION
In quick sampling mode, the `measurement_start` is not being called, causing the test names to be omitted from the bencher report output.

Before the fix:

```
% cargo bench -- --quick --output-format=bencher
bench:           0 ns/iter (+/- 0)
bench:           7 ns/iter (+/- 0)
```

After the fix:

```
% cargo bench -- --quick --output-format=bencher
test Fibonacci/Recursive ... bench:           0 ns/iter (+/- 0)
test Fibonacci/Iterative ... bench:           7 ns/iter (+/- 0)
```