### PR TITLE
feat(deps): Make alloca optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ exclude = ["book/*"]
 anes = "0.1.4"
 criterion-plot = { path = "plot", version = "0.8.2" }
 itertools = "0.13"
-page_size = "0.6"
 serde = { version = "1.0.100", features = ["derive"] }
 serde_json = "1.0.100"
 ciborium = "0.2.0"
@@ -62,7 +61,8 @@ tokio = { version = "1.0", default-features = false, features = [
 ], optional = true }
 
 [target.'cfg(any(windows, unix))'.dependencies]
-alloca = "0.4"
+alloca = { version = "0.4", optional = true }
+page_size = { version = "0.6", optional = true }
 
 [dependencies.plotters]
 version = "^0.3.2"
@@ -85,10 +85,13 @@ stable = [
     "async_smol",
     "async_tokio",
 ]
-default = ["rayon", "plotters", "cargo_bench_support"]
+default = ["rayon", "plotters", "cargo_bench_support", "alloca"]
 
 # This is a legacy feature that no longer does anything, but removing it would be a semver break.
 real_blackbox = []
+
+# Enable alloca-based memory layout randomization.
+alloca = ["dep:alloca", "dep:page_size"]
 
 # Enable rayon support
 rayon = ["dep:rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,8 @@ default = ["rayon", "plotters", "cargo_bench_support", "alloca"]
 # This is a legacy feature that no longer does anything, but removing it would be a semver break.
 real_blackbox = []
 
-# Enable alloca-based memory layout randomization.
+# Enable alloca-based memory layout randomization. Reduces bias from memory
+# alignment and cache effects.
 alloca = ["dep:alloca", "dep:page_size"]
 
 # Enable rayon support

--- a/src/routine.rs
+++ b/src/routine.rs
@@ -250,7 +250,7 @@ where
         let mut results = Vec::with_capacity(iters.len());
         results.resize(iters.len(), 0.0);
         for (i, iters) in iters.iter().enumerate() {
-            #[cfg(any(target_family = "unix", target_family = "windows"))]
+            #[cfg(all(feature = "alloca", any(target_family = "unix", target_family = "windows")))]
             {
                 // Intentionally vary the stack allocation size to reduce measurement bias from
                 // memory alignment and cache effects.
@@ -265,7 +265,7 @@ where
                     },
                 );
             }
-            #[cfg(not(any(target_family = "unix", target_family = "windows")))]
+            #[cfg(not(all(feature = "alloca", any(target_family = "unix", target_family = "windows"))))]
             {
                 b.iters = *iters;
                 (*f)(&mut b, black_box(parameter));

--- a/src/routine.rs
+++ b/src/routine.rs
@@ -250,7 +250,10 @@ where
         let mut results = Vec::with_capacity(iters.len());
         results.resize(iters.len(), 0.0);
         for (i, iters) in iters.iter().enumerate() {
-            #[cfg(all(feature = "alloca", any(target_family = "unix", target_family = "windows")))]
+            #[cfg(all(
+                feature = "alloca",
+                any(target_family = "unix", target_family = "windows")
+            ))]
             {
                 // Intentionally vary the stack allocation size to reduce measurement bias from
                 // memory alignment and cache effects.
@@ -265,7 +268,10 @@ where
                     },
                 );
             }
-            #[cfg(not(all(feature = "alloca", any(target_family = "unix", target_family = "windows"))))]
+            #[cfg(not(all(
+                feature = "alloca",
+                any(target_family = "unix", target_family = "windows")
+            )))]
             {
                 b.iters = *iters;
                 (*f)(&mut b, black_box(parameter));


### PR DESCRIPTION
#83 

- This makes `alloca` optional. `alloca` was introduced in version `0.8` and fails on some setups
- A no-op for most as `alloca` is enabled by default.