### PR TITLE
Replace itertools dependency with methods from the standard library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,6 @@ dependencies = [
  "criterion-plot",
  "csv",
  "futures",
- "itertools",
  "num-traits",
  "oorandom",
  "page_size",
@@ -316,7 +315,6 @@ name = "criterion-plot"
 version = "0.8.2"
 dependencies = [
  "cast",
- "itertools",
  "itertools-num",
  "num-complex",
  "rand",
@@ -564,15 +562,6 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools-num"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ exclude = ["book/*"]
 [dependencies]
 anes = "0.1.4"
 criterion-plot = { path = "plot", version = "0.8.2" }
-itertools = "0.13"
 serde = { version = "1.0.100", features = ["derive"] }
 serde_json = "1.0.100"
 ciborium = "0.2.0"

--- a/plot/Cargo.toml
+++ b/plot/Cargo.toml
@@ -12,7 +12,6 @@ version.workspace = true
 
 [dependencies]
 cast = "0.3"
-itertools = "0.13"
 
 [dev-dependencies]
 itertools-num = "0.1"

--- a/plot/src/candlestick.rs
+++ b/plot/src/candlestick.rs
@@ -140,7 +140,12 @@ where
         } = candlesticks;
 
         let data = Matrix::new(
-            itertools::izip!(x, box_min, whisker_min, whisker_high, box_high),
+            x.into_iter()
+                .zip(std::iter::zip(
+                    box_min.into_iter().zip(whisker_min),
+                    whisker_high.into_iter().zip(box_high),
+                ))
+                .map(|(x, ((bm, wm), (wh, bh)))| (x, bm, wm, wh, bh)),
             (x_factor, y_factor, y_factor, y_factor, y_factor),
         );
         self.plots

--- a/plot/src/curve.rs
+++ b/plot/src/curve.rs
@@ -262,7 +262,7 @@ where
         let (x_factor, y_factor) =
             crate::scale_factor(&self.axes, props.axes.unwrap_or(crate::Axes::BottomXLeftY));
 
-        let data = Matrix::new(itertools::izip!(x, y), (x_factor, y_factor));
+        let data = Matrix::new(x.into_iter().zip(y), (x_factor, y_factor));
         self.plots.push(Plot::new(data, &props));
         self
     }

--- a/plot/src/errorbar.rs
+++ b/plot/src/errorbar.rs
@@ -1,13 +1,13 @@
 //! Error bar plots
 
-use std::borrow::Cow;
-
 use crate::data::Matrix;
 use crate::traits::{self, Data, Set};
 use crate::{
     Color, Display, ErrorBarDefault, Figure, Label, LineType, LineWidth, Plot, PointSize,
     PointType, Script,
 };
+use std::borrow::Cow;
+use std::iter;
 
 /// Properties common to error bar plots
 pub struct Properties {
@@ -259,7 +259,8 @@ where
             } => (x, y, y_low, y_high, y_factor),
         };
         let data = Matrix::new(
-            itertools::izip!(x, y, length, height),
+            iter::zip(x.into_iter().zip(y), length.into_iter().zip(height))
+                .map(|((x, y), (l, h))| (x, y, l, h)),
             (x_factor, y_factor, e_factor, e_factor),
         );
         self.plots.push(Plot::new(

--- a/plot/src/filledcurve.rs
+++ b/plot/src/filledcurve.rs
@@ -132,7 +132,12 @@ where
         let (x_factor, y_factor) =
             crate::scale_factor(&self.axes, props.axes.unwrap_or(crate::Axes::BottomXLeftY));
 
-        let data = Matrix::new(itertools::izip!(x, y1, y2), (x_factor, y_factor, y_factor));
+        let data = Matrix::new(
+            x.into_iter()
+                .zip(y1.into_iter().zip(y2))
+                .map(|(x, (y1, y2))| (x, y1, y2)),
+            (x_factor, y_factor, y_factor),
+        );
         self.plots.push(Plot::new(data, &props));
         self
     }

--- a/src/plot/gnuplot_backend/summary.rs
+++ b/src/plot/gnuplot_backend/summary.rs
@@ -12,7 +12,6 @@ use {
         AxisScale,
     },
     criterion_plot::prelude::*,
-    itertools::Itertools,
     std::{
         cmp::Ordering,
         path::{Path, PathBuf},
@@ -98,8 +97,9 @@ pub(crate) fn line_comparison(
     // This assumes the curves are sorted. It also assumes that the benchmark IDs all have numeric
     // values or throughputs and that value is sensible (ie. not a mix of bytes and elements
     // or whatnot)
-    for (key, group) in &all_curves.iter().chunk_by(|&&&(id, _)| &id.function_id) {
-        let mut tuples: Vec<_> = group
+    for chunk in all_curves.chunk_by(|a, b| a.0.function_id == b.0.function_id) {
+        let mut tuples: Vec<_> = chunk
+            .into_iter()
             .map(|&&(id, ref sample)| {
                 // Unwrap is fine here because it will only fail if the assumptions above are not true
                 // ie. programmer error.
@@ -114,7 +114,11 @@ pub(crate) fn line_comparison(
         tuples.sort_by(|&(ax, _), &(bx, _)| ax.partial_cmp(&bx).unwrap_or(Ordering::Less));
         let (xs, ys): (Vec<_>, Vec<_>) = tuples.into_iter().unzip();
 
-        let function_name = key.as_ref().map(|string| gnuplot_escape(string));
+        let function_name = chunk[0]
+            .0
+            .function_id
+            .as_ref()
+            .map(|string| gnuplot_escape(string));
 
         f.plot(Lines { x: &xs, y: &ys }, |c| {
             if let Some(name) = function_name {

--- a/src/plot/plotters_backend/summary.rs
+++ b/src/plot/plotters_backend/summary.rs
@@ -1,7 +1,6 @@
 use {
     super::*,
     crate::AxisScale,
-    itertools::Itertools,
     plotters::coord::{
         ranged1d::{AsRangedCoord, ValueFormatter as PlottersValueFormatter},
         Shift,
@@ -147,8 +146,9 @@ fn line_comparison_series_data<'a>(
     // This assumes the curves are sorted. It also assumes that the benchmark IDs all have numeric
     // values or throughputs and that value is sensible (ie. not a mix of bytes and elements
     // or whatnot)
-    for (key, group) in &all_curves.iter().chunk_by(|&&&(id, _)| &id.function_id) {
-        let mut tuples: Vec<_> = group
+    for chunk in all_curves.chunk_by(|a, b| a.0.function_id == b.0.function_id) {
+        let mut tuples: Vec<_> = chunk
+            .into_iter()
             .map(|&&(id, ref sample)| {
                 // Unwrap is fine here because it will only fail if the assumptions above are not true
                 // ie. programmer error.
@@ -161,7 +161,7 @@ fn line_comparison_series_data<'a>(
             })
             .collect();
         tuples.sort_by(|&(ax, _), &(bx, _)| ax.partial_cmp(&bx).unwrap_or(Ordering::Less));
-        let function_name = key.as_ref();
+        let function_name = chunk[0].0.function_id.as_ref();
         let (xs, ys): (Vec<_>, Vec<_>) = tuples.into_iter().unzip();
         series_data.push((function_name, xs, ys));
     }


### PR DESCRIPTION
While doing a dependency audit we noticed that we had a dependency on an old version of `itertools` exclusively through `criterion`. Looking at the code, it seemed relatively trivial to replace the dependency with methods from the standard library instead of bumping the dependency version.

The `izip` macro is just a small wrapper around zipping multiple iterators, it only saves a tiny bit of code.

A [`chunk_by`](https://doc.rust-lang.org/beta/core/primitive.slice.html#method.chunk_by) method was added to slices and stabilized in Rust 1.77. The method is slightly more generic, since it takes a comparison function instead of a key extractor.