### PR TITLE
feat: use a Tableau 20 palette for line comparison charts

### DIFF
--- a/src/plot/gnuplot_backend/summary.rs
+++ b/src/plot/gnuplot_backend/summary.rs
@@ -20,16 +20,30 @@ use {
     },
 };
 
-const NUM_COLORS: usize = 8;
+// Tableau 20: the Tableau 10 hues first, then their lighter variants, so that
+// groups with few series get the most separated colors.
+const NUM_COLORS: usize = 20;
 static COMPARISON_COLORS: [Color; NUM_COLORS] = [
-    Color::Rgb(178, 34, 34),
-    Color::Rgb(46, 139, 87),
-    Color::Rgb(0, 139, 139),
-    Color::Rgb(255, 215, 0),
-    Color::Rgb(0, 0, 139),
-    Color::Rgb(220, 20, 60),
-    Color::Rgb(139, 0, 139),
-    Color::Rgb(0, 255, 127),
+    Color::Rgb(31, 119, 180),
+    Color::Rgb(255, 127, 14),
+    Color::Rgb(44, 160, 44),
+    Color::Rgb(214, 39, 40),
+    Color::Rgb(148, 103, 189),
+    Color::Rgb(140, 86, 75),
+    Color::Rgb(227, 119, 194),
+    Color::Rgb(127, 127, 127),
+    Color::Rgb(188, 189, 34),
+    Color::Rgb(23, 190, 207),
+    Color::Rgb(174, 199, 232),
+    Color::Rgb(255, 187, 120),
+    Color::Rgb(152, 223, 138),
+    Color::Rgb(255, 152, 150),
+    Color::Rgb(197, 176, 213),
+    Color::Rgb(196, 156, 148),
+    Color::Rgb(247, 182, 210),
+    Color::Rgb(199, 199, 199),
+    Color::Rgb(219, 219, 141),
+    Color::Rgb(158, 218, 229),
 ];
 
 impl AxisScale {

--- a/src/plot/plotters_backend/summary.rs
+++ b/src/plot/plotters_backend/summary.rs
@@ -9,16 +9,30 @@ use {
     std::{cmp::Ordering, path::Path},
 };
 
-const NUM_COLORS: usize = 8;
+// Tableau 20: the Tableau 10 hues first, then their lighter variants, so that
+// groups with few series get the most separated colors.
+const NUM_COLORS: usize = 20;
 static COMPARISON_COLORS: [RGBColor; NUM_COLORS] = [
-    RGBColor(178, 34, 34),
-    RGBColor(46, 139, 87),
-    RGBColor(0, 139, 139),
-    RGBColor(255, 215, 0),
-    RGBColor(0, 0, 139),
-    RGBColor(220, 20, 60),
-    RGBColor(139, 0, 139),
-    RGBColor(0, 255, 127),
+    RGBColor(31, 119, 180),
+    RGBColor(255, 127, 14),
+    RGBColor(44, 160, 44),
+    RGBColor(214, 39, 40),
+    RGBColor(148, 103, 189),
+    RGBColor(140, 86, 75),
+    RGBColor(227, 119, 194),
+    RGBColor(127, 127, 127),
+    RGBColor(188, 189, 34),
+    RGBColor(23, 190, 207),
+    RGBColor(174, 199, 232),
+    RGBColor(255, 187, 120),
+    RGBColor(152, 223, 138),
+    RGBColor(255, 152, 150),
+    RGBColor(197, 176, 213),
+    RGBColor(196, 156, 148),
+    RGBColor(247, 182, 210),
+    RGBColor(199, 199, 199),
+    RGBColor(219, 219, 141),
+    RGBColor(158, 218, 229),
 ];
 
 pub(crate) fn line_comparison(


### PR DESCRIPTION
Reference PR for #42, not necessarily meant to be merged as-is.

The line comparison chart picks colors from an 8-entry table indexed by `id % NUM_COLORS`, so a group with more than 8 functions reuses colors. This replaces that table with Tableau 20 in both backends, reordered so the 10 Tableau 10 hues come first and their lighter variants after, instead of the usual interleaved dark/light pairs, so that a group with only a handful of series still gets the most visually separated colors.

This does not fix #42. The colors are still not configurable, and the table is still indexed modulo its length. It just pushes the wrap-around point from 9 series to 21.

---

22 functions in one group, plotters backend:

| before | after |
| --- | --- |
| <img width="960" height="540" alt="lines_before" src="https://github.com/user-attachments/assets/5244c9d2-107c-4071-9b81-ebcb39bbd3e7" /> | <img width="960" height="540" alt="lines_after" src="https://github.com/user-attachments/assets/bd0c8be5-744e-4831-a0a6-5e45f5328e05" /> |



