### PR TITLE
Remove redundant casts and clone

### DIFF
--- a/src/analysis/compare.rs
+++ b/src/analysis/compare.rs
@@ -70,7 +70,7 @@ pub(crate) fn common(
         relative_distributions,
         iters,
         times,
-        base_avg_times.clone(),
+        base_avg_times,
         base_estimates,
     ))
 }

--- a/src/plot/gnuplot_backend/pdf.rs
+++ b/src/plot/gnuplot_backend/pdf.rs
@@ -231,7 +231,7 @@ pub(crate) fn pdf_small(
 ) -> Child {
     let avg_times = &*measurements.avg_times;
     let typical = avg_times.max();
-    let mut scaled_avg_times: Vec<f64> = (avg_times as &Sample<f64>).iter().cloned().collect();
+    let mut scaled_avg_times: Vec<f64> = avg_times.iter().cloned().collect();
     let unit = formatter.scale_values(typical, &mut scaled_avg_times);
     let scaled_avg_times = Sample::new(&scaled_avg_times);
     let mean = scaled_avg_times.mean();

--- a/src/plot/plotters_backend/pdf.rs
+++ b/src/plot/plotters_backend/pdf.rs
@@ -116,7 +116,7 @@ pub(crate) fn pdf_small(
 ) {
     let avg_times = &*measurements.avg_times;
     let typical = avg_times.max();
-    let mut scaled_avg_times: Vec<f64> = (avg_times as &Sample<f64>).iter().cloned().collect();
+    let mut scaled_avg_times: Vec<f64> = avg_times.iter().cloned().collect();
     let unit = formatter.scale_values(typical, &mut scaled_avg_times);
     let scaled_avg_times = Sample::new(&scaled_avg_times);
     let mean = scaled_avg_times.mean();


### PR DESCRIPTION
I believe both the casts and the clone are redundant in these cases and can thus be safely removed.

For reference, these changes were found by an optimizer developed as a research project.

CC @nunoplopes
